### PR TITLE
Tracker Exceptions to list all calls

### DIFF
--- a/TeePee.Tests/TeePeeTests.cs
+++ b/TeePee.Tests/TeePeeTests.cs
@@ -288,6 +288,25 @@ namespace TeePee.Tests
 
         #endregion
 
+        #region Not Matched
+        
+        [Fact]
+        public async Task TrackerThrowsIfMatchNotMade()
+        {
+            // Given
+            var verify = RequestMatchBuilder().TrackRequest();
+            var httpRequestMessage = RequestMessage(HttpMethod.Put, m_Url);
+            await SendRequest(httpRequestMessage);
+
+            // When
+            void Verify() => verify.WasCalled();
+
+            // Then
+            Assert.Throws<IncorrectExpectedRequests>(Verify);
+        }
+
+        #endregion
+
         #region Responds With
 
         [Fact]

--- a/TeePee.Tests/TeePeeTests.cs
+++ b/TeePee.Tests/TeePeeTests.cs
@@ -18,6 +18,8 @@ namespace TeePee.Tests
     /// </summary>
     public class TeePeeTests
     {
+        private readonly ITestOutputHelper m_TestOutputHelper;
+
         // URL and Method used for each test
         private string m_Url = "https://www.test.co.uk/api/items";
         private HttpMethod m_HttpMethod = HttpMethod.Get;
@@ -37,6 +39,7 @@ namespace TeePee.Tests
 
         public TeePeeTests(ITestOutputHelper testOutputHelper)
         {
+            m_TestOutputHelper = testOutputHelper;
             m_MockLogger = new Mock<ILogger<TeePee>>();
             m_MockLogger.Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<EventId>(), It.IsAny<It.IsAnyType>(), It.IsAny<Exception>(), It.IsAny<Func<It.IsAnyType, Exception, string>>()))
                         .Callback(new InvocationAction(invocation =>
@@ -288,7 +291,7 @@ namespace TeePee.Tests
 
         #endregion
 
-        #region Not Matched
+        #region Tracker Specific
         
         [Fact]
         public async Task TrackerThrowsIfMatchNotMade()
@@ -302,7 +305,24 @@ namespace TeePee.Tests
             void Verify() => verify.WasCalled();
 
             // Then
-            Assert.Throws<IncorrectExpectedRequests>(Verify);
+            var ex = Assert.Throws<MismatchedTrackerExpectedCalls>(Verify);
+            m_TestOutputHelper.WriteLine(ex.Message);
+        }
+        
+        [Fact]
+        public async Task TrackerDoesNotThrowIfMatchMade()
+        {
+            // Given
+            var verify = RequestMatchBuilder().TrackRequest();
+            var httpRequestMessage = RequestMessage(HttpMethod.Put, m_Url);
+            await SendRequest(httpRequestMessage);
+
+            // When
+            void Verify() => verify.WasNotCalled();
+
+            // Then
+            var ex = Record.Exception(Verify);
+            Assert.Null(ex);
         }
 
         #endregion

--- a/TeePee/DependencyInjection/Resolve.cs
+++ b/TeePee/DependencyInjection/Resolve.cs
@@ -19,7 +19,7 @@ namespace TeePee.DependencyInjection
             return serviceCollection.BuildServiceProvider().GetService<T>();
         }
 
-        public static T WithNamedClients<T>(Action<IServiceCollection> configureServices = null, params TeePeeBuilder[] teePeeBuilders) where T : class
+        public static T WithNamedClients<T>(Action<IServiceCollection>? configureServices = null, params TeePeeBuilder[] teePeeBuilders) where T : class
         {
             var serviceCollection = new ServiceCollection();
 
@@ -28,6 +28,9 @@ namespace TeePee.DependencyInjection
             foreach (var teePeeBuilder in teePeeBuilders)
             {
                 var teePee = teePeeBuilder.Build();
+
+                if (teePee.HttpClientNamedInstance == null)
+                    throw new InvalidOperationException($"'{nameof(WithNamedClients)}' requires the '{nameof(TeePee.HttpClientNamedInstance)}' to be set.");
 
                 if (configureServices != null)
                 {
@@ -50,7 +53,7 @@ namespace TeePee.DependencyInjection
             return serviceCollection.BuildServiceProvider().GetService<T>();
         }
         
-        public static T WithTypedClient<T, TClient>(TeePeeBuilder teePeeBuilder, Action<IServiceCollection> configureServices = null) where T : class where TClient : class
+        public static T WithTypedClient<T, TClient>(TeePeeBuilder teePeeBuilder, Action<IServiceCollection>? configureServices = null) where T : class where TClient : class
         {
             var serviceCollection = new ServiceCollection();
 
@@ -74,9 +77,9 @@ namespace TeePee.DependencyInjection
             return serviceCollection.BuildServiceProvider().GetService<T>();
         }
         
-        public static T WithTypedClients<T, TClient1, TClient2>(TeePeeBuilder<TClient1> teePeeBuilder1, TeePeeBuilder<TClient2> teePeeBuilder2, Action<IServiceCollection> setup = null) where T : class 
-                                                                                                                                                                                                where TClient1 : class
-                                                                                                                                                                                                where TClient2 : class
+        public static T WithTypedClients<T, TClient1, TClient2>(TeePeeBuilder<TClient1> teePeeBuilder1, TeePeeBuilder<TClient2> teePeeBuilder2, Action<IServiceCollection>? setup = null) where T : class 
+                                                                                                                                                                                          where TClient1 : class
+                                                                                                                                                                                          where TClient2 : class
         {
             var serviceCollection = new ServiceCollection();
             

--- a/TeePee/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/TeePee/DependencyInjection/ServiceCollectionExtensions.cs
@@ -27,8 +27,13 @@ namespace TeePee.DependencyInjection
             var a = nameof(HttpClientFactoryOptions);
 #pragma warning restore 219
             var type = Type.GetType("Microsoft.Extensions.Internal.TypeNameHelper, Microsoft.Extensions.Http");
+            if (type == null)
+                throw new InvalidOperationException("Could not find TypeNameHelper in assemblies");
             var method = type.GetMethod("GetTypeDisplayName", BindingFlags.Static | BindingFlags.Public, null, CallingConventions.Any, new[] { typeof(Type), typeof(bool), typeof(bool), typeof(bool), typeof(char) }, null);
+            if (method == null)
+                throw new InvalidOperationException("Could not find method TypeNameHelper.GetTypeDisplayName in assemblies");
             var httpClientNamedInstance = (string)method.Invoke(null, new[] { (object)typedClientType, false, false, true, '+' });
+
 
             // Reflection: Create an HttpClientBuilder using the same ServiceCollection and HttpClientFactoryName used within the Startup
             var builder = serviceCollection.GetHttpClientBuilderFor(httpClientNamedInstance);
@@ -44,6 +49,8 @@ namespace TeePee.DependencyInjection
         {
             // Service Collection must be the same one that was used to originally register the type.
             var defaultHttpClientBuilderType = Type.GetType("Microsoft.Extensions.DependencyInjection.DefaultHttpClientBuilder, Microsoft.Extensions.Http");
+            if (defaultHttpClientBuilderType == null)
+                throw new InvalidOperationException("Could not find method DefaultHttpClientBuilder in assemblies");
             return (IHttpClientBuilder)Activator.CreateInstance(defaultHttpClientBuilderType, serviceCollection, httpClientNamedInstance);
         }
 
@@ -55,7 +62,7 @@ namespace TeePee.DependencyInjection
                                                               .ToList();
 
             if (!namedClientOptionsServices.Any())
-                throw new InvalidOperationException($"No registration found for Named Client '{httpClientNamedInstance}'. {namedClientOptionsServices.Count} registrations found [{string.Join(',', namedClientOptionsServices.Select(o => $"'{o.Name}'"))}].");
+                throw new InvalidOperationException($"No registration found for Named Client '{httpClientNamedInstance}'. {namedClientOptionsServices.Count} registrations found [{string.Join(',', namedClientOptionsServices.Select(o => $"'{o!.Name}'"))}].");
         }
     }
 }

--- a/TeePee/Extensions/HttpRequestMessageExtensions.cs
+++ b/TeePee/Extensions/HttpRequestMessageExtensions.cs
@@ -5,7 +5,7 @@ namespace TeePee.Extensions
 {
     public static class HttpRequestMessageExtensions
     {
-        public static async Task<string> ReadContentAsync(this HttpRequestMessage httpRequestMessage)
+        public static async Task<string?> ReadContentAsync(this HttpRequestMessage httpRequestMessage)
         {
             if (httpRequestMessage.Content == null)
                 return null;

--- a/TeePee/Extensions/HttpRequestMessageExtensions.cs
+++ b/TeePee/Extensions/HttpRequestMessageExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace TeePee.Extensions
+{
+    public static class HttpRequestMessageExtensions
+    {
+        public static async Task<string> ReadContentAsync(this HttpRequestMessage httpRequestMessage)
+        {
+            if (httpRequestMessage.Content == null)
+                return null;
+
+            return await httpRequestMessage.Content.ReadAsStringAsync();
+        }
+    }
+}

--- a/TeePee/Extensions/StringExtensions.cs
+++ b/TeePee/Extensions/StringExtensions.cs
@@ -4,7 +4,7 @@ namespace TeePee.Extensions
 {
     internal static class StringExtensions
     {
-        internal static bool IsSameString(this string source, string dest) => string.Equals(source, dest, StringComparison.OrdinalIgnoreCase);
+        internal static bool IsSameString(this string? source, string? dest) => string.Equals(source, dest, StringComparison.OrdinalIgnoreCase);
 
         internal static string Trunc(this string value) => value.Length > 50 ? $"{value.Substring(0, 50)}..." : value;
     }

--- a/TeePee/Extensions/StringExtensions.cs
+++ b/TeePee/Extensions/StringExtensions.cs
@@ -4,8 +4,10 @@ namespace TeePee.Extensions
 {
     internal static class StringExtensions
     {
+        private const int _TRUNCATE_BODY_LENGTH = 500;
+
         internal static bool IsSameString(this string? source, string? dest) => string.Equals(source, dest, StringComparison.OrdinalIgnoreCase);
 
-        internal static string Trunc(this string value) => value.Length > 50 ? $"{value.Substring(0, 50)}..." : value;
+        internal static string Trunc(this string value) => value.Length > _TRUNCATE_BODY_LENGTH ? $"{value.Substring(0, _TRUNCATE_BODY_LENGTH)}..." : value;
     }
 }

--- a/TeePee/Internal/RequestMatchRule.cs
+++ b/TeePee/Internal/RequestMatchRule.cs
@@ -12,11 +12,11 @@ namespace TeePee.Internal
     internal class RequestMatchRule
     {
         private readonly Response m_Response;
-        private readonly Tracker m_Tracker;
+        private readonly Tracker? m_Tracker;
 
-        public string Url { get; }
+        public string? Url { get; }
         public HttpMethod Method { get; }
-        public string RequestBody { get; }
+        public string? RequestBody { get; }
         public string RequestBodyMediaType { get; }
         public Encoding RequestBodyEncoding { get; }
         public ReadOnlyDictionary<string, string> QueryParams { get; } 
@@ -24,8 +24,8 @@ namespace TeePee.Internal
 
         internal int SpecificityLevel => (RequestBody == null ? 0 : 1) + QueryParams.Count + Headers.Count;
 
-        internal RequestMatchRule(string url, HttpMethod method, string requestBody, string requestBodyMediaType, Encoding requestBodyEncoding, 
-                              IDictionary<string, string> queryParams, IDictionary<string, string> headers, Response response, Tracker tracker)
+        internal RequestMatchRule(string? url, HttpMethod method, string? requestBody, string requestBodyMediaType, Encoding requestBodyEncoding, 
+                              IDictionary<string, string> queryParams, IDictionary<string, string> headers, Response response, Tracker? tracker)
         {
             Url = url;
             Method = method;
@@ -102,7 +102,7 @@ namespace TeePee.Internal
 
         public override string ToString()
         {
-            return $"{Method} {Url} [Q: {QueryParams?.Flat()}] [H: {Headers?.Flat()}] [B: {RequestBody?.Trunc()}]";
+            return $"{Method} {Url} [Q: {QueryParams.Flat()}] [H: {Headers.Flat()}] [B: {RequestBody?.Trunc()}]";
         }
         
         internal HttpResponseMessage ToHttpResponseMessage() => m_Response.ToHttpResponseMessage();

--- a/TeePee/Internal/Response.cs
+++ b/TeePee/Internal/Response.cs
@@ -13,13 +13,13 @@ namespace TeePee.Internal
         
         private readonly JsonSerializerOptions m_BodySerializeOptions;
 
-        private readonly object m_ResponseBody;
+        private readonly object? m_ResponseBody;
         private readonly string m_ResponseBodyMediaType;
         private readonly Encoding m_ResponseBodyEncoding; 
 
         private readonly ReadOnlyDictionary<string, string> m_ResponseHeaders;
 
-        public Response(HttpStatusCode responseStatusCode, JsonSerializerOptions bodySerializeOptions, object responseBody, string responseBodyMediaType, Encoding responseBodyEncoding, IDictionary<string, string> responseHeaders)
+        public Response(HttpStatusCode responseStatusCode, JsonSerializerOptions bodySerializeOptions, object? responseBody, string responseBodyMediaType, Encoding responseBodyEncoding, IDictionary<string, string> responseHeaders)
         {
             m_ResponseStatusCode = responseStatusCode;
 
@@ -44,7 +44,7 @@ namespace TeePee.Internal
             return response;
         }
         
-        private HttpContent BodyAsContent()
+        private HttpContent? BodyAsContent()
         {
             if (m_ResponseBody == null)
                 return null;

--- a/TeePee/RequestMatchBuilder.cs
+++ b/TeePee/RequestMatchBuilder.cs
@@ -13,14 +13,15 @@ namespace TeePee
     {
         private readonly TeePeeBuilder m_ParentTrackingBuilder;
         private readonly JsonSerializerOptions m_BodySerializeOptions;
-        private ResponseBuilder m_ResponseBuilder;
-        private Tracker m_Tracker;
+
+        private ResponseBuilder? m_ResponseBuilder;
+        private Tracker? m_Tracker;
         
         private string Url { get; }
         private HttpMethod Method { get; }
-        private object RequestBody { get; set; }
-        private Encoding RequestBodyEncoding { get; set; }
-        private string RequestBodyMediaType { get; set; }
+        private object? RequestBody { get; set; }
+        private string RequestBodyMediaType { get; set; } = "application/json";
+        private Encoding RequestBodyEncoding { get; set; } = Encoding.UTF8;
         
         private Dictionary<string, string> QueryParams { get; } = new Dictionary<string, string>();
         private Dictionary<string, string> Headers { get; } = new Dictionary<string, string>();
@@ -64,7 +65,7 @@ namespace TeePee
             return url;
         }
 
-        public RequestMatchBuilder WithBody<T>(T body, string mediaType = "application/json", Encoding encoding = null)
+        public RequestMatchBuilder WithBody<T>(T body, string? mediaType = "application/json", Encoding? encoding = null)
         {
             if (body == null)
                 throw new ArgumentNullException();
@@ -73,8 +74,10 @@ namespace TeePee
                 throw new InvalidOperationException("The matching Body has already been added to this request match.");
 
             RequestBody = body;
-            RequestBodyEncoding = encoding ?? Encoding.UTF8;
-            RequestBodyMediaType = mediaType;
+            if (mediaType != null)
+                RequestBodyMediaType = mediaType;
+            if (encoding != null)
+                RequestBodyEncoding = encoding;
             return this;
         }
 

--- a/TeePee/RequestMatchBuilder.cs
+++ b/TeePee/RequestMatchBuilder.cs
@@ -105,13 +105,13 @@ namespace TeePee
             return m_ResponseBuilder;
         }
 
-        internal RequestMatchRule ToRequestMatch()
+        internal RequestMatchRule ToRequestMatchRule(List<TeePeeMessageHandler.RecordedHttpCall> recordedHttpCalls)
         {
             var serialisedRequestBody = RequestBody == null ? null : JsonSerializer.Serialize(RequestBody); // TODO: JSON Serialiser options
             var response = m_ResponseBuilder == null 
                                ? ResponseBuilder.DefaultResponse()
                                : m_ResponseBuilder.ToHttpResponse();
-            return new RequestMatchRule(Url, Method, serialisedRequestBody, RequestBodyMediaType, RequestBodyEncoding, QueryParams, Headers, response, m_Tracker);
+            return new RequestMatchRule(Url, Method, serialisedRequestBody, RequestBodyMediaType, RequestBodyEncoding, QueryParams, Headers, response, m_Tracker, recordedHttpCalls);
         }
 
         public Tracker TrackRequest()

--- a/TeePee/RequestMatchBuilder.cs
+++ b/TeePee/RequestMatchBuilder.cs
@@ -102,13 +102,13 @@ namespace TeePee
             return m_ResponseBuilder;
         }
 
-        internal RequestMatch ToRequestMatch()
+        internal RequestMatchRule ToRequestMatch()
         {
             var serialisedRequestBody = RequestBody == null ? null : JsonSerializer.Serialize(RequestBody); // TODO: JSON Serialiser options
             var response = m_ResponseBuilder == null 
                                ? ResponseBuilder.DefaultResponse()
                                : m_ResponseBuilder.ToHttpResponse();
-            return new RequestMatch(Url, Method, serialisedRequestBody, RequestBodyMediaType, RequestBodyEncoding, QueryParams, Headers, response, m_Tracker);
+            return new RequestMatchRule(Url, Method, serialisedRequestBody, RequestBodyMediaType, RequestBodyEncoding, QueryParams, Headers, response, m_Tracker);
         }
 
         public Tracker TrackRequest()

--- a/TeePee/ResponseBuilder.cs
+++ b/TeePee/ResponseBuilder.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Net;
-using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using TeePee.Internal;
@@ -9,14 +8,17 @@ namespace TeePee
 {
     public class ResponseBuilder
     {
+        private static readonly string s_DefaultResponseBodyMediaType = "application/json";
+        private static readonly Encoding s_DefaultResponseBodyEncoding = Encoding.UTF8; 
+        
         private readonly RequestMatchBuilder m_RequestMatchBuilder;
         private readonly JsonSerializerOptions m_BodySerializeOptions;
 
         private HttpStatusCode m_ResponseStatusCode = HttpStatusCode.NoContent;
 
-        private object m_ResponseBody;
-        private string m_ResponseBodyMediaType;
-        private Encoding m_ResponseBodyEncoding; 
+        private object? m_ResponseBody;
+        private string m_ResponseBodyMediaType = s_DefaultResponseBodyMediaType;
+        private Encoding m_ResponseBodyEncoding = s_DefaultResponseBodyEncoding; 
 
         private readonly Dictionary<string, string> m_ResponseHeaders = new Dictionary<string, string>();
         
@@ -32,11 +34,13 @@ namespace TeePee
             return this;
         }
         
-        public ResponseBuilder WithBody<T>(T body, string? mediaType = null, Encoding encoding = null)
+        public ResponseBuilder WithBody<T>(T body, string? mediaType = null, Encoding? encoding = null)
         {
             m_ResponseBody = body;
-            m_ResponseBodyMediaType = mediaType ?? "application/json";
-            m_ResponseBodyEncoding = encoding ?? Encoding.UTF8;
+            if (mediaType != null)
+                m_ResponseBodyMediaType = mediaType;
+            if (encoding != null)
+                m_ResponseBodyEncoding = encoding;
             return this;
         }
         
@@ -53,7 +57,7 @@ namespace TeePee
 
         internal static Response DefaultResponse()
         {
-            return new Response(HttpStatusCode.Accepted, null, null, null, null, new Dictionary<string, string>());
+            return new Response(HttpStatusCode.Accepted, new JsonSerializerOptions(), null, s_DefaultResponseBodyMediaType, s_DefaultResponseBodyEncoding, new Dictionary<string, string>());
         }
 
         public Tracker TrackRequest()

--- a/TeePee/TeePee.cs
+++ b/TeePee/TeePee.cs
@@ -11,11 +11,11 @@ namespace TeePee
 {
     public class TeePee
     {
-        internal string HttpClientNamedInstance { get; }
+        internal string? HttpClientNamedInstance { get; }
 
         public TeePeeMessageHandler HttpHandler { get; }
         
-        internal TeePee(string httpClientNamedInstance, TeePeeMode mode, List<RequestMatchRule> matches, HttpStatusCode unmatchedStatusCode, string unmatchedBody, ILogger logger)
+        internal TeePee(string? httpClientNamedInstance, TeePeeMode mode, List<RequestMatchRule> matches, HttpStatusCode unmatchedStatusCode, string? unmatchedBody, ILogger? logger)
         {
             HttpClientNamedInstance = httpClientNamedInstance;
             HttpHandler = new TeePeeMessageHandler(mode, matches, 
@@ -33,18 +33,18 @@ namespace TeePee
          * The CreateClient / Create HttpClientFactory only needed for Manual Injection
          */
 
-        public ManualTeePee Manual(string baseAddressForHttpClient = null)
+        public ManualTeePee Manual(string? baseAddressForHttpClient = null)
         {
             return new ManualTeePee(this, baseAddressForHttpClient);
         }
 
         public class ManualTeePee
         {
-            private readonly Uri m_BaseAddressForHttpClient;
+            private readonly Uri? m_BaseAddressForHttpClient;
 
             public TeePee TeePee { get; }
 
-            internal ManualTeePee(TeePee teePee, string baseAddressForHttpClient)
+            internal ManualTeePee(TeePee teePee, string? baseAddressForHttpClient)
             {
                 m_BaseAddressForHttpClient = baseAddressForHttpClient == null ? null : new Uri(baseAddressForHttpClient);
                 TeePee = teePee;
@@ -64,7 +64,7 @@ namespace TeePee
                 private readonly HttpClient m_HttpClient;
                 private readonly string m_NamedInstance;
 
-                internal WrappedHttpClientFactory(HttpClient httpClient, string namedInstance)
+                internal WrappedHttpClientFactory(HttpClient httpClient, string? namedInstance)
                 {
                     m_HttpClient = httpClient;
                     m_NamedInstance = namedInstance ?? Microsoft.Extensions.Options.Options.DefaultName; // Default value used by actual HttpClientFactoryExtensions.CreateClient();
@@ -101,7 +101,7 @@ namespace TeePee
         {
             private readonly Dictionary<string, HttpClient> m_NamedClients = new Dictionary<string, HttpClient>();
 
-            internal void Add(string namedInstance, HttpClient httpClient)
+            internal void Add(string? namedInstance, HttpClient httpClient)
             {
                 namedInstance ??= Microsoft.Extensions.Options.Options.DefaultName;
                 m_NamedClients.Add(namedInstance, httpClient);

--- a/TeePee/TeePee.cs
+++ b/TeePee/TeePee.cs
@@ -15,10 +15,10 @@ namespace TeePee
 
         public TeePeeMessageHandler HttpHandler { get; }
         
-        internal TeePee(string? httpClientNamedInstance, TeePeeMode mode, List<RequestMatchRule> matches, HttpStatusCode unmatchedStatusCode, string? unmatchedBody, ILogger? logger)
+        internal TeePee(string? httpClientNamedInstance, TeePeeMode mode, List<RequestMatchBuilder> matchRuleBuilders, HttpStatusCode unmatchedStatusCode, string? unmatchedBody, ILogger? logger)
         {
             HttpClientNamedInstance = httpClientNamedInstance;
-            HttpHandler = new TeePeeMessageHandler(mode, matches, 
+            HttpHandler = new TeePeeMessageHandler(mode, matchRuleBuilders, 
                                                          () => new HttpResponseMessage(unmatchedStatusCode)
                                                                {
                                                                    Content = unmatchedBody == null 

--- a/TeePee/TeePee.cs
+++ b/TeePee/TeePee.cs
@@ -15,7 +15,7 @@ namespace TeePee
 
         public TeePeeMessageHandler HttpHandler { get; }
         
-        internal TeePee(string httpClientNamedInstance, TeePeeMode mode, List<RequestMatch> matches, HttpStatusCode unmatchedStatusCode, string unmatchedBody, ILogger logger)
+        internal TeePee(string httpClientNamedInstance, TeePeeMode mode, List<RequestMatchRule> matches, HttpStatusCode unmatchedStatusCode, string unmatchedBody, ILogger logger)
         {
             HttpClientNamedInstance = httpClientNamedInstance;
             HttpHandler = new TeePeeMessageHandler(mode, matches, 

--- a/TeePee/TeePee.csproj
+++ b/TeePee/TeePee.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/oatsoda/TeePee</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageIcon>teepee-icon.png</PackageIcon>
+	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TeePee/TeePeeBuilder.cs
+++ b/TeePee/TeePeeBuilder.cs
@@ -20,22 +20,22 @@ namespace TeePee
                                                                                       }
                                                                                   };
 
-        private readonly string m_HttpClientNamedInstance;
+        private readonly string? m_HttpClientNamedInstance;
         private readonly TeePeeMode m_Mode;
         private readonly TeePeeBuilderMode m_BuilderMode;
         private readonly JsonSerializerOptions m_BodySerializeOptions;
         private readonly List<RequestMatchBuilder> m_Requests = new List<RequestMatchBuilder>();
         
         private HttpStatusCode m_DefaultResponseStatusCode = HttpStatusCode.NotFound;
-        private string m_DefaultResponseBody;
+        private string? m_DefaultResponseBody;
 
         private bool m_IsBuilt;
         
         public TeePeeBuilder() : this(default) { }
 
-        public TeePeeBuilder(JsonSerializerOptions bodySerializeOptions = default) : this(null, default, default, bodySerializeOptions) { }
+        public TeePeeBuilder(JsonSerializerOptions? bodySerializeOptions = default) : this(null, default, default, bodySerializeOptions) { }
 
-        public TeePeeBuilder(string httpClientNamedInstance = null, TeePeeMode mode = TeePeeMode.Lenient, TeePeeBuilderMode builderMode = TeePeeBuilderMode.AllowMultipleUrlRules, JsonSerializerOptions bodySerializeOptions = default)
+        public TeePeeBuilder(string? httpClientNamedInstance = null, TeePeeMode mode = TeePeeMode.Lenient, TeePeeBuilderMode builderMode = TeePeeBuilderMode.AllowMultipleUrlRules, JsonSerializerOptions? bodySerializeOptions = default)
         {
             m_HttpClientNamedInstance = httpClientNamedInstance;
             m_Mode = mode;
@@ -43,7 +43,7 @@ namespace TeePee
             m_BodySerializeOptions = bodySerializeOptions ?? s_DefaultSerializeOptions;
         }
         
-        public TeePeeBuilder WithDefaultResponse(HttpStatusCode responseStatusCode, string responseBody = null)
+        public TeePeeBuilder WithDefaultResponse(HttpStatusCode responseStatusCode, string? responseBody = null)
         {
             m_DefaultResponseStatusCode = responseStatusCode;
             m_DefaultResponseBody = responseBody;
@@ -69,7 +69,7 @@ namespace TeePee
             return builder;
         }
 
-        public TeePee Build(ILogger<TeePee> logger = null)
+        public TeePee Build(ILogger<TeePee>? logger = null)
         {
             m_IsBuilt = true;
             var requestMatches = m_Requests.Select(b => b.ToRequestMatch()).ToList();

--- a/TeePee/TeePeeBuilder.cs
+++ b/TeePee/TeePeeBuilder.cs
@@ -72,8 +72,7 @@ namespace TeePee
         public TeePee Build(ILogger<TeePee>? logger = null)
         {
             m_IsBuilt = true;
-            var requestMatches = m_Requests.Select(b => b.ToRequestMatch()).ToList();
-            return new TeePee(m_HttpClientNamedInstance, m_Mode, requestMatches, m_DefaultResponseStatusCode, m_DefaultResponseBody, logger);
+            return new TeePee(m_HttpClientNamedInstance, m_Mode, m_Requests, m_DefaultResponseStatusCode, m_DefaultResponseBody, logger);
         }
 
         internal bool HasMatchUrlWithQuery()

--- a/TeePee/Tracker.cs
+++ b/TeePee/Tracker.cs
@@ -2,26 +2,28 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
+using TeePee.Extensions;
 using TeePee.Internal;
 
 namespace TeePee
 {
     public class Tracker
     {
-        private readonly List<(TeePeeMessageHandler.HttpRecord Record, string RequestBody)> m_Calls = new List<(TeePeeMessageHandler.HttpRecord, string)>();
+        private readonly List<(TeePeeMessageHandler.RecordedHttpCall Record, string RequestBody)> m_Calls = new List<(TeePeeMessageHandler.RecordedHttpCall, string)>();
 
-        private RequestMatch m_RequestMatch;
+        private RequestMatchRule m_RequestMatchRule;
 
         public IEnumerable<(string RequestBody, HttpResponseMessage Response)> Calls => m_Calls.Select(c => (c.RequestBody, c.Record.HttpResponseMessage));
 
-        internal void SetRequestMatch(RequestMatch requestMatch)
+        internal void SetRequestMatchRule(RequestMatchRule requestMatchRule)
         {
-            m_RequestMatch = requestMatch;
+            m_RequestMatchRule = requestMatchRule;
         }
 
         public void WasCalled(int? times = null)
         {
-            if (m_RequestMatch == null)
+            if (m_RequestMatchRule == null)
                 throw new InvalidOperationException($"Tracker was not attached to a Request Match. Ensure that you Built the {nameof(TeePeeBuilder)} instance.");
 
             var asExpected = times == null
@@ -33,16 +35,16 @@ namespace TeePee
 
             var msgTimes = times == null ? "at least once" : $"exactly {times.Value} times";
             var msgNotMet = times == null ? "never called" : $"call {m_Calls.Count} times";
-            var msg = $"Expected match on {m_RequestMatch} {msgTimes} but was {msgNotMet}.";
+            var msg = $"Expected match on {m_RequestMatchRule} {msgTimes} but was {msgNotMet}.";
             throw new IncorrectExpectedRequests(msg);
         }
 
         public void WasNotCalled() => WasCalled(0);
 
-        internal void AddCallInstance(TeePeeMessageHandler.HttpRecord httpRecord)
+        internal async Task AddCallInstance(TeePeeMessageHandler.RecordedHttpCall recordedHttpCall)
         {
-            var requestBody = httpRecord.HttpRequestMessage.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
-            m_Calls.Add((httpRecord, requestBody));
+            var requestBody = await recordedHttpCall.HttpRequestMessage.ReadContentAsync();
+            m_Calls.Add((recordedHttpCall, requestBody));
         }
     }
 

--- a/TeePee/Tracker.cs
+++ b/TeePee/Tracker.cs
@@ -10,11 +10,11 @@ namespace TeePee
 {
     public class Tracker
     {
-        private readonly List<(TeePeeMessageHandler.RecordedHttpCall Record, string RequestBody)> m_Calls = new List<(TeePeeMessageHandler.RecordedHttpCall, string)>();
+        private readonly List<(TeePeeMessageHandler.RecordedHttpCall Record, string? RequestBody)> m_Calls = new List<(TeePeeMessageHandler.RecordedHttpCall, string?)>();
 
-        private RequestMatchRule m_RequestMatchRule;
+        private RequestMatchRule? m_RequestMatchRule;
 
-        public IEnumerable<(string RequestBody, HttpResponseMessage Response)> Calls => m_Calls.Select(c => (c.RequestBody, c.Record.HttpResponseMessage));
+        public IEnumerable<(string? RequestBody, HttpResponseMessage Response)> Calls => m_Calls.Select(c => (c.RequestBody, c.Record.HttpResponseMessage));
 
         internal void SetRequestMatchRule(RequestMatchRule requestMatchRule)
         {

--- a/TeePee/Tracker.cs
+++ b/TeePee/Tracker.cs
@@ -34,7 +34,7 @@ namespace TeePee
             var msgTimes = times == null ? "at least once" : $"exactly {times.Value} times";
             var msgNotMet = times == null ? "never called" : $"call {m_Calls.Count} times";
             var msg = $"Expected match on {m_RequestMatch} {msgTimes} but was {msgNotMet}.";
-            throw new InvalidOperationException(msg);
+            throw new IncorrectExpectedRequests(msg);
         }
 
         public void WasNotCalled() => WasCalled(0);
@@ -43,6 +43,14 @@ namespace TeePee
         {
             var requestBody = httpRecord.HttpRequestMessage.Content?.ReadAsStringAsync().GetAwaiter().GetResult();
             m_Calls.Add((httpRecord, requestBody));
+        }
+    }
+
+    public class IncorrectExpectedRequests : Exception
+    {
+        public IncorrectExpectedRequests(string message) : base(message)
+        {
+            
         }
     }
 }


### PR DESCRIPTION
Implements #7 

- Add `Nullable`
- Remove multiple Request Body reads, along with blocking GetAwaiter.GetResult.