### PR TITLE
Choose latest rule when multiple match

### DIFF
--- a/TeePee.Tests/TeePeeTests.cs
+++ b/TeePee.Tests/TeePeeTests.cs
@@ -271,6 +271,25 @@ namespace TeePee.Tests
             verifyUrlOnly.WasNotCalled();
             verifyUrlAndBody.WasCalled();
         }
+
+        [Fact]
+        public async Task MatchesMostRecentRuleIfMultipleSameRules()
+        {
+            // Given
+            var bodyObject = new { Test = 1 };
+            var verifyUrlOne = RequestMatchBuilder().WithBody(bodyObject).TrackRequest();
+            var verifyUrlTwo = RequestMatchBuilder().WithBody(bodyObject).TrackRequest();
+
+            var httpRequestMessage = RequestMessage();
+            httpRequestMessage.Content = new StringContent(JsonSerializer.Serialize(bodyObject), Encoding.UTF8, "application/json");
+
+            // When
+            await SendRequest(httpRequestMessage);
+
+            // Then
+            verifyUrlOne.WasNotCalled();
+            verifyUrlTwo.WasCalled();
+        }
         
         [Theory]
         [InlineData(false)]

--- a/TeePee/Internal/RequestMatchRule.cs
+++ b/TeePee/Internal/RequestMatchRule.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Net.Http;
@@ -13,6 +14,8 @@ namespace TeePee.Internal
         private readonly Response m_Response;
         private readonly Tracker? m_Tracker;
 
+        internal DateTimeOffset CreatedAt { get; }
+        
         public string? Url { get; }
         public HttpMethod Method { get; }
         public string? RequestBody { get; }
@@ -23,10 +26,12 @@ namespace TeePee.Internal
 
         internal int SpecificityLevel => (RequestBody == null ? 0 : 1) + QueryParams.Count + Headers.Count;
 
-        internal RequestMatchRule(string? url, HttpMethod method, string? requestBody, string requestBodyMediaType, Encoding requestBodyEncoding, 
+        internal RequestMatchRule(DateTimeOffset createdAt, string? url, HttpMethod method, string? requestBody, string requestBodyMediaType, Encoding requestBodyEncoding, 
                               IDictionary<string, string> queryParams, IDictionary<string, string> headers, Response response, Tracker? tracker, 
                               List<TeePeeMessageHandler.RecordedHttpCall> recordedHttpCalls)
         {
+            CreatedAt = createdAt;
+
             Url = url;
             Method = method;
             RequestBody = requestBody;

--- a/TeePee/RequestMatchBuilder.cs
+++ b/TeePee/RequestMatchBuilder.cs
@@ -16,7 +16,9 @@ namespace TeePee
 
         private ResponseBuilder? m_ResponseBuilder;
         private Tracker? m_Tracker;
-        
+
+        private readonly DateTimeOffset m_CreatedAt = DateTimeOffset.UtcNow;
+
         private string Url { get; }
         private HttpMethod Method { get; }
         private object? RequestBody { get; set; }
@@ -111,7 +113,7 @@ namespace TeePee
             var response = m_ResponseBuilder == null 
                                ? ResponseBuilder.DefaultResponse()
                                : m_ResponseBuilder.ToHttpResponse();
-            return new RequestMatchRule(Url, Method, serialisedRequestBody, RequestBodyMediaType, RequestBodyEncoding, QueryParams, Headers, response, m_Tracker, recordedHttpCalls);
+            return new RequestMatchRule(m_CreatedAt, Url, Method, serialisedRequestBody, RequestBodyMediaType, RequestBodyEncoding, QueryParams, Headers, response, m_Tracker, recordedHttpCalls);
         }
 
         public Tracker TrackRequest()

--- a/TeePee/TeePee.cs
+++ b/TeePee/TeePee.cs
@@ -1,11 +1,10 @@
-﻿using System;
+﻿using Microsoft.Extensions.Logging;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using Microsoft.Extensions.Logging;
 using TeePee.Extensions;
-using TeePee.Internal;
 
 namespace TeePee
 {

--- a/TeePee/TeePeeBuilderMode.cs
+++ b/TeePee/TeePeeBuilderMode.cs
@@ -3,9 +3,13 @@
     public enum TeePeeBuilderMode
     {
         /// <summary>
-        /// Requests seeded in TeePee
+        /// Requests seeded in TeePee do not need to have unique URLs.
         /// </summary>
         AllowMultipleUrlRules = 0,
+
+        /// <summary>
+        /// Requests seeded in TeePee must have unique URLs.
+        /// </summary>
         RequireUniqueUrlRules
     }
 }


### PR DESCRIPTION
Order rules by CreatedAt after Specificity to allow rules to be "overwritten".

#31 